### PR TITLE
Make ASDF 3.2 happy with eco

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.x86f
 *~
 .#*
+t/test.lisp

--- a/src/asdf.lisp
+++ b/src/asdf.lisp
@@ -33,7 +33,7 @@
 
 (defmethod perform ((op load-op) (component eco-template))
   (let ((compiled-template-path (compiled-template-path component)))
-    (perform (make-instance 'load-source-op)
+    (perform 'load-source-op
              (make-instance 'cl-source-file
                             :name (component-name component)
                             :parent (component-parent component)


### PR DESCRIPTION
Do NOT use make-instance on an operation, use make-operation, or better,
just pass a symbol to the relevant API function.

Also, ignore a generated test file.