### PR TITLE
Bug fixes/updates and new primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A basic template (`.eco` extension) looks like this:
       <% if posts %>
         <h1>Recent Posts</h1>
         <ul id="post-list">
-          <% loop for (title . snippet) in posts %>
+          <% loop for (title . snippet) in posts do %>
             <li><%= title %> - <%= snippet %></li>
           <% end %>
         </ul>
@@ -60,8 +60,18 @@ To execute the template:
 (eco-template:index "My Blog" nil)
 ```
 
-**Note:** Eco is designed to be output-agnostic, so by default it will **not**
-autoescape HTML. Use the `e` function for that. You have been warned.
+Eco is designed to be output-agnostic, however, by default it will
+autoescape HTML for convenience. Specify :ESCAPE-HTML NIL when
+defining each template to disable this behaviour individually for each
+template.
+
+```erb
+<% deftemplate output-js-logger (module) (:escape-html nil) %>
+   function logDebug (message) {
+       console.log("<%= module %>: " + message);
+   }
+<% end %>
+```
 
 # Tags
 

--- a/eco-test.asd
+++ b/eco-test.asd
@@ -9,4 +9,6 @@
                 :components
                 ((:file "eco")
                  (:eco-template "test")
-                 (:file "test-asdf")))))
+                 (:file "test-asdf")
+                 (:eco-template "compiler")
+                 (:file "test-compiler")))))

--- a/eco.asd
+++ b/eco.asd
@@ -4,6 +4,7 @@
   :license "MIT"
   :homepage "https://github.com/eudoxia0/eco"
   :depends-on (:esrap
+               :alexandria
                :split-sequence
                :cl-who)
   :components ((:module "src"

--- a/src/asdf.lisp
+++ b/src/asdf.lisp
@@ -28,7 +28,9 @@
                       (component-pathname component)))
              (compiled (eco.compiler:compile-template
                         parsed
-                        (template-package component))))
+                        (template-package component)))
+             ;; Need to maintain reference EQuality for uninterned symbols.
+             (*print-circle* t))
         (print compiled stream)))))
 
 (defmethod perform ((op load-op) (component eco-template))

--- a/src/compiler.lisp
+++ b/src/compiler.lisp
@@ -76,6 +76,16 @@
                              (coerce body 'list))
              collecting (emit elem))))))
 
+(defmethod emit ((call <call>))
+  `(princ (,@(read-template-expressions (code call))
+           ,@(let ((children (loop
+                                for elem across (body call)
+                                collecting (emit elem))))
+               (and children
+                    `((with-output-to-string (%eco-stream)
+                        ,@children)))))
+          %eco-stream))
+
 (defun template-element-p (element)
   (typep element '<block>))
 

--- a/src/compiler.lisp
+++ b/src/compiler.lisp
@@ -1,4 +1,3 @@
-(in-package :cl-user)
 
 ;;; eco-template: The package where templates are compiled
 
@@ -23,65 +22,71 @@
               `(progn
                  ,@body))))
      (compile ',name)
-     (export ',name (find-package 'eco-template))))
+     (export ',name (symbol-package ',name))))
 
 (defpackage eco.compiler
-  (:use :cl :eco.parser)
+  (:use :cl :eco.parser :eco-template)
   (:import-from :split-sequence
                 :split-sequence-if)
+  (:import-from :eco-template
+                :%eco-stream)
   (:export :compile-template))
 (in-package :eco.compiler)
+
+(defparameter *template-package*
+  (find-package 'eco-template))
+
+(defun read-template-expressions (string)
+  (let ((*package* *template-package*)
+        (end '#:eof))
+    (with-input-from-string (s string)
+      (loop
+         for form = (read s nil end)
+         until (eq form end)
+         collect form))))
 
 ;;; Compiler
 
 (defmethod emit ((str string))
-  (format nil "(write-string ~S eco-stream)" str))
+  `(write-string ,str %eco-stream))
 
 (defmethod emit ((vec vector))
-  (format nil "(progn ~{~A ~})"
-          (loop for elem across vec collecting (emit elem))))
+  `(progn ,@(loop for elem across vec collecting (emit elem))))
 
 (defmethod emit ((expr <expr-tag>))
-  (format nil "(write-string (e ~A) eco-stream)" (code expr)))
+  (let ((expressions (read-template-expressions (code expr))))
+    (assert (= 1 (length expressions))
+            (expressions) "Only one expression is allowed in <%= <expr> %>, got ~{~S~%~}"
+            expressions)
+    (alexandria:with-unique-names (string-stream)
+      `(write-string (e (with-output-to-string (,string-stream)
+                          (princ ,(first expressions) ,string-stream)))
+                     %eco-stream))))
 
-(defmethod emit ((else <else-tag>)) "")
+(defun else-tag-p (element)
+  (typep element '<else-tag>))
 
 (defmethod emit ((block <block>))
   (let ((body (body block)))
     (if (typep body 'string)
         body
-        (let ((else-tag-pos (position nil body :test #'(lambda (a b)
-                                                         (typep b '<else-tag>)))))
-          (if else-tag-pos
-              ;; We have an else tag
-              (format nil "(~A ~{~A ~})"
-                      (code block)
-                      (loop for elem in (split-sequence-if #'(lambda (elem)
-                                                               (typep elem '<else-tag>))
-                                                           body)
-                            collecting (format nil "(progn ~A)" (emit elem))))
-              ;; Just a regular block
-              (format nil "(~A ~{~A ~})"
-                      (code block)
-                      (loop for elem across body collecting (emit elem))))))))
+        (let ((else-tag-pos (position-if 'else-tag-p body)))
+          `(,@(read-template-expressions (code block))
+            ,@(loop
+                 for elem in (if else-tag-pos
+                                 (split-sequence-if 'else-tag-p body)
+                                 (coerce body 'list))
+                 collecting (emit elem)))))))
 
+(defun template-element-p (element)
+  (typep element '<block>))
 
 (defun emit-toplevel (code)
-  (format nil "(progn ~{~A~%~})"
-          (loop for elem across code collecting
-            (if (typep elem '<block>)
-                (emit elem)
-                ""))))
+  `(progn ,@(map 'list 'emit (remove-if-not 'template-element-p code))))
 
 ;;; Interface
 
-(defun read-string-in-package (string package-name)
-  (let ((cur-package *package*))
-    (setf *package* (find-package package-name))
-    (prog1
-        (read-from-string string)
-      (setf *package* cur-package))))
-
 (defun compile-template (element &optional (package-name 'eco-template))
-  (read-string-in-package (emit-toplevel element) package-name))
+  (let ((*template-package* (find-package package-name)))
+    (emit-toplevel element)))
 

--- a/src/compiler.lisp
+++ b/src/compiler.lisp
@@ -68,15 +68,13 @@
 
 (defmethod emit ((block <block>))
   (let ((body (body block)))
-    (if (typep body 'string)
-        body
-        (let ((else-tag-pos (position-if 'else-tag-p body)))
-          `(,@(read-template-expressions (code block))
-            ,@(loop
-                 for elem in (if else-tag-pos
-                                 (split-sequence-if 'else-tag-p body)
-                                 (coerce body 'list))
-                 collecting (emit elem)))))))
+    (let ((else-tag-pos (position-if 'else-tag-p body)))
+      `(,@(read-template-expressions (code block))
+        ,@(loop
+             for elem in (if else-tag-pos
+                             (split-sequence-if 'else-tag-p body)
+                             (coerce body 'list))
+             collecting (emit elem))))))
 
 (defun template-element-p (element)
   (typep element '<block>))

--- a/t/compiler.eco
+++ b/t/compiler.eco
@@ -1,0 +1,15 @@
+<% deftemplate compiler-1 (hello) () %>
+<%= hello %>abc
+<% end %>
+
+<% deftemplate compiler-2 (x y) () %>
+<%- concatenate 'string x y %>body<% end %>
+<% end %>
+
+<% deftemplate compiler-3 () () %>
+<%- compiler-2 "word1" %>word2<% end %>
+<% end %>
+
+<% deftemplate compiler-4 () () %>
+<% compiler-2 "a" %>b<% end %>
+<% end %>

--- a/t/example.eco
+++ b/t/example.eco
@@ -1,4 +1,4 @@
-<% deftemplate (index title &optional posts) () %>
+<% deftemplate index (title &optional posts) () %>
   <!DOCTYPE html>
   <html>
     <head>
@@ -8,7 +8,7 @@
       <% if posts %>
         <h1>Recent Posts</h1>
         <ul id="post-list">
-          <% loop for (title . snippet) in posts %>
+          <% loop for (title . snippet) in posts do %>
             <li><%= title %> - <%= snippet %></li>
           <% end %>
         </ul>

--- a/t/test-compiler.lisp
+++ b/t/test-compiler.lisp
@@ -18,21 +18,21 @@
      "<% block %>missing end tag"))
 
   (progn
-    (is (equal (eco-template::compiler-1 "input")
+    (is (equal (eco-template:compiler-1 "input")
                "
 inputabc
 "))
-    (is (equal (eco-template::compiler-2 "[input1]" "[input2]")
+    (is (equal (eco-template:compiler-2 "[input1]" "[input2]")
                "
 [input1][input2]body
 "))
-    (is (equal (eco-template::compiler-3)
+    (is (equal (eco-template:compiler-3)
                "
 
 word1word2body
 
 "))
-    (is (equal (eco-template::compiler-4)
+    (is (equal (eco-template:compiler-4)
                "
 b
 "))))

--- a/t/test-compiler.lisp
+++ b/t/test-compiler.lisp
@@ -1,0 +1,40 @@
+
+(in-package :eco-test)
+
+(def-suite compiler)
+(in-suite compiler)
+
+(test compiler
+  (signals error
+    (progn
+      (eco:compile-string
+       "<% deftemplate error-test (hello x y z) () %>
+<%= hello x y z%>abc
+<% end %>")
+      (eco-template::error-test "hello" 1 2 3)))
+
+  (signals error
+    (eco:compile-string
+     "<% block %>missing end tag"))
+
+  (progn
+    (is (equal (eco-template::compiler-1 "input")
+               "
+inputabc
+"))
+    (is (equal (eco-template::compiler-2 "[input1]" "[input2]")
+               "
+[input1][input2]body
+"))
+    (is (equal (eco-template::compiler-3)
+               "
+
+word1word2body
+
+"))
+    (is (equal (eco-template::compiler-4)
+               "
+b
+"))))
+
+(run! 'compiler)


### PR DESCRIPTION
I've updated/fixed the README file and changed the code generation/compiler, switching away from string manipulation to manipulation of S-exps (as a good Lisp program should do).

So up till 416644f, I hope it is pretty straight-forward?

From that commit onwards, notably in 63d833c, I've made a possibly more controversial change by adding the <%- fun arg1 arg2 ...  %>body<% end %>  primitive (the CALL primitive).

I could not reconcile the way call works with the current block <% block %>, so only introduced it reluctantly. It is used for calling functions and passing in big bodies (one of the primary reasons for for templates, all the start and end tag business is useful when there's lots of content in between). The traditional block construct seems to be unable to support "nested" calls due to the order of side-effects. An example is shown in the new "compiler" tests I've also added in 3e8c18a :

<% deftemplate compiler-2 (x y) () %>
<%- concatenate 'string x y %>body<% end %>
<% end %>

<% deftemplate compiler-4 () () %>
<% compiler-2 "a" %>b<% end %>
<% end %>

Ignoring the details of compiler-2 for now, the issue for me had been that compiler-4 is unable to make use of compiler-2 (nested call to another template) and only outputs (ignoring whitespace) "b"

The <%- call construct supports this use case by invoking the template "compiler-2", substituting all input argument values appropriately, and inserting its contents (compiler-2 output) into the location of the original call (in "compiler-4").

If this is merged, I will be able to update the README to reflect the additional of this new primitive.

Keen to see if this works for ECO, or if not, hear what you think.
